### PR TITLE
Fix swapped DACL & SACL offsets

### DIFF
--- a/libfwnt/libfwnt_security_descriptor.c
+++ b/libfwnt/libfwnt_security_descriptor.c
@@ -360,11 +360,11 @@ int libfwnt_security_descriptor_copy_from_byte_stream(
 
 	byte_stream_copy_to_uint32_little_endian(
 	 &( byte_stream[ 12 ] ),
-	 discretionary_acl_offset );
+	 system_acl_offset );
 
 	byte_stream_copy_to_uint32_little_endian(
 	 &( byte_stream[ 16 ] ),
-	 system_acl_offset );
+	 discretionary_acl_offset );
 
 #if defined( HAVE_DEBUG_OUTPUT )
 	if( libcnotify_verbose != 0 )


### PR DESCRIPTION
In the security descriptor parsing, DACL offset and SACL offset are swapped, giving incorrect results. DACL offset is at position 16, SACL offset at position 12.

References:
https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-security_descriptor?redirectedfrom=MSDN
https://github.com/tuxera/ntfs-3g/blob/a4a837025b6ac2b0c44c93e34e22535fe9e95b27/ntfsprogs/ntfssecaudit.c#L1276