### PR TITLE
Export libfwnt_locale_identifier_language_tag_get_identifier

### DIFF
--- a/include/libfwnt.h.in
+++ b/include/libfwnt.h.in
@@ -128,6 +128,10 @@ int libfwnt_error_backtrace_sprint(
  * Locale identifier (LCID) functions
  * ------------------------------------------------------------------------- */
 
+LIBFWNT_EXTERN \
+const char *libfwnt_locale_identifier_language_tag_get_identifier(
+             uint16_t lcid_language_tag );
+
 /* -------------------------------------------------------------------------
  * Security descriptor functions
  * ------------------------------------------------------------------------- */

--- a/libfwnt/libfwnt_locale_identifier.h
+++ b/libfwnt/libfwnt_locale_identifier.h
@@ -25,6 +25,8 @@
 #include <common.h>
 #include <types.h>
 
+#include "libfwnt_extern.h"
+
 #if defined( __cplusplus )
 extern "C" {
 #endif
@@ -46,6 +48,7 @@ struct libfwnt_locale_identifier_language_tag
 	const char *description;
 };
 
+LIBFWNT_EXTERN \
 const char *libfwnt_locale_identifier_language_tag_get_identifier(
              uint16_t lcid_language_tag );
 


### PR DESCRIPTION
`libfwnt_locale_identifier_language_tag_get_identifier` is used externally, by libwrc. Hence, it needs to be exported for DLLs to work correctly. This patch corrects that problem.